### PR TITLE
Replace appcompat dependency with support-annotations

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:support-annotations:23.1.1'
 }

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -23,7 +23,7 @@
 
     <style name="ToggleDrawable">
         <item name="td_drawableSize">24dp</item>
-        <item name="td_color">?attr/colorAccent</item>
+        <item name="td_color">?android:attr/textColorPrimary</item>
         <item name="td_spin">true</item>
         <item name="td_stroke">2dp</item>
     </style>


### PR DESCRIPTION
As proposed in #2, `support-annotations` has only 20 methods, compared to `appcompat-v7`'s 14k+ methods. I simply replace `?attr/colorAccent` with `?android:attr/textColorPrimary`, but it can be anything really.
